### PR TITLE
Using CryptoSuites for JWS Sign and JWE Decrypt

### DIFF
--- a/lib/crypto/rsa/RsaCryptoSuite.ts
+++ b/lib/crypto/rsa/RsaCryptoSuite.ts
@@ -8,9 +8,6 @@ import * as constants from 'constants';
 import PrivateKey from '../../security/PrivateKey';
 import PublicKey from '../../security/PublicKey';
 
-// TODO: Rewrite to allow additional cryptographic algorithms to be added easily then remove dependency on 'node-jose'.
-const jose = require('node-jose');
-
 /**
  * Encrypter plugin for RsaSignature2018
  */
@@ -93,11 +90,10 @@ export class RsaCryptoSuite implements CryptoSuite {
    * @returns Signed payload in compact JWS format.
    */
   public static async signRs512 (content: string, jwk: PrivateKey): Promise<string> {
-    let contentBuffer = Buffer.from(content);
-
-    const contentJwsString = await jose.JWS.createSign({ format: 'compact', fields: {} }, jwk).update(contentBuffer).final();
-
-    return contentJwsString;
+    const privateKey = jwkToPem(jwk, { private: true });
+    const signer = crypto.createSign('RSA-SHA512');
+    signer.update(content);
+    return signer.sign(privateKey, 'base64');
   }
 
   /**

--- a/lib/crypto/rsa/RsaCryptoSuite.ts
+++ b/lib/crypto/rsa/RsaCryptoSuite.ts
@@ -111,8 +111,8 @@ export class RsaCryptoSuite implements CryptoSuite {
    * TODO: correctly implement this after getting rid of node-jose dependency.
    */
   public static decryptRsaOaep (data: Buffer, jwk: PrivateKey): Buffer {
-    const publicKey = jwkToPem(jwk);
-    const decryptedDataBuffer = crypto.publicDecrypt({ key: publicKey, padding: constants.RSA_PKCS1_OAEP_PADDING }, data);
+    const privateKey = jwkToPem(jwk, { private: true });
+    const decryptedDataBuffer = crypto.privateDecrypt({ key: privateKey, padding: constants.RSA_PKCS1_OAEP_PADDING }, data);
 
     return decryptedDataBuffer;
   }

--- a/lib/crypto/rsa/RsaCryptoSuite.ts
+++ b/lib/crypto/rsa/RsaCryptoSuite.ts
@@ -65,10 +65,10 @@ export class RsaCryptoSuite implements CryptoSuite {
    * @returns Signed payload in compact JWS format.
    */
   public static async signRs256 (content: string, jwk: PrivateKey): Promise<string> {
-    let contentBuffer = Buffer.from(content);
-    const contentJwsString = await jose.JWS.createSign({ format: 'compact', fields: {} }, jwk).update(contentBuffer).final();
-
-    return contentJwsString;
+    const privateKey = jwkToPem(jwk, { private: true });
+    const signer = crypto.createSign('RSA-SHA256');
+    signer.update(content);
+    return signer.sign(privateKey, 'base64');
   }
 
   /**

--- a/lib/interfaces/CryptoSuite.ts
+++ b/lib/interfaces/CryptoSuite.ts
@@ -32,8 +32,10 @@ export default interface CryptoSuite {
  * Interface for Encryption/Decryption
  */
 export interface Encrypter {
+  /** Given the data to encrypt and a JWK public key, encrypts the data */
   encrypt (data: Buffer, jwk: PublicKey): Buffer;
 
+  /** Given the encrypted data and a jwk private key, decrypts the data */
   decrypt (data: Buffer, jwk: PrivateKey): Buffer;
 }
 
@@ -41,7 +43,12 @@ export interface Encrypter {
  *  Interface for Signing/Signature Verification
  */
 export interface Signer {
+  /** Given signature input content and a JWK private key, creates and returns a signature as a base64 string */
   sign (content: string, jwk: PrivateKey): Promise<string>;
 
+  /**
+   * Given the content used in the original signature input, the signature, and a JWK public key,
+   * returns true if the signature is valid, else false
+   */
   verify (signedContent: string, signature: string, jwk: PublicKey): boolean;
 }

--- a/lib/security/JweToken.ts
+++ b/lib/security/JweToken.ts
@@ -158,6 +158,20 @@ export default class JweToken extends JoseToken {
     // 16. Decrypt JWE Ciphertext using CEK, IV, AAD, and authTag, using "enc" algorithm.
 
     // TODO: complex work involving symmetric key encryption here
+    const cryptoMap: {[enc: string]: string} = {
+      A128GCM: 'aes-128-gcm',
+      A192GCM: 'aes-192-gcm',
+      A256GCM: 'aes-256-gcm'
+    }
+    const enc = cryptoMap[headers.enc];
+
+    const decipher = crypto.createDecipheriv(enc, cek, iv);
+    decipher.setAAD(Buffer.from(aad, 'utf-8'));
+    decipher.setAuthTag(Buffer.from(authTag, 'utf-8'));
+    const plaintext = decipher.update(Buffer.from(cipherText, 'ignored because data is a Buffer', 'utf-8'));
+    if (decipher.final().length !== 0) {
+      throw new Error('crypto cipher final returned additional data');
+    }
 
     // 17. if a "zip" parameter was included, uncompress the plaintext using the specified algorithm
     if ('zip' in headers) {

--- a/lib/security/JweToken.ts
+++ b/lib/security/JweToken.ts
@@ -126,7 +126,7 @@ export default class JweToken extends JoseToken {
     });
     if ('crit' in headers) { // RFC7516 4.1.13/RFC7515 4.1.11
       const extensions = headers.crit as string[];
-      if (extensions) {
+      if (extensions.filter) {
         // TODO: determine which additional header fields are supported
         const supported: string[] = [];
         const unsupported = extensions.filter((extension) => { return !(extension in supported); });

--- a/lib/security/JweToken.ts
+++ b/lib/security/JweToken.ts
@@ -162,7 +162,7 @@ export default class JweToken extends JoseToken {
       A128GCM: 'aes-128-gcm',
       A192GCM: 'aes-192-gcm',
       A256GCM: 'aes-256-gcm'
-    }
+    };
     const enc = cryptoMap[headers.enc];
 
     const decipher = crypto.createDecipheriv(enc, cek, iv);

--- a/lib/security/JweToken.ts
+++ b/lib/security/JweToken.ts
@@ -109,7 +109,7 @@ export default class JweToken extends JoseToken {
   public async decrypt (jwk: PrivateKey): Promise<string> {
     // following steps for JWE Decryption in RFC7516 section 5.2
     // 1. Parse JWE for components: BASE64URL(UTF8(JWE Header)) || '.' || BASE64URL(JWE Encrypted Key) || '.' ||
-    //    BASE64URL(JWE Initialization Vector) || '.' || BASE64URL(JWE Ciphertext) || '.' || 
+    //    BASE64URL(JWE Initialization Vector) || '.' || BASE64URL(JWE Ciphertext) || '.' ||
     //    BASE64URL(JWE Authentication Tag)
     const base64EncodedValues = this.content.split('.');
     // 2. Base64url decode the encoded header, encryption key, iv, ciphertext, and auth tag
@@ -121,11 +121,11 @@ export default class JweToken extends JoseToken {
     // 5. verify header fields
     ['alg', 'enc', 'kid'].forEach((header: string) => {
       if (!(header in headers)) {
-        throw new Error(`Missing required header: ${header}`)
+        throw new Error(`Missing required header: ${header}`);
       }
     });
     if ('crit' in headers) { // RFC7516 4.1.13/RFC7515 4.1.11
-      const extensions = headers.crit as string[]
+      const extensions = headers.crit as string[];
       if (extensions) {
         // TODO: determine which additional header fields are supported
         const supported: string[] = [];
@@ -156,7 +156,7 @@ export default class JweToken extends JoseToken {
     // 15. Let the Additional Authentication Data (AAD) be ASCII(encodedprotectedHeader)
     const aad = base64EncodedValues[0];
     // 16. Decrypt JWE Ciphertext using CEK, IV, AAD, and authTag, using "enc" algorithm.
-    
+
     // TODO: complex work involving symmetric key encryption here
 
     // 17. if a "zip" parameter was included, uncompress the plaintext using the specified algorithm

--- a/lib/security/JweToken.ts
+++ b/lib/security/JweToken.ts
@@ -2,10 +2,7 @@ import * as crypto from 'crypto';
 import Base64Url from '../utilities/Base64Url';
 import JoseToken from './JoseToken';
 import PublicKey from '../security/PublicKey';
-import { PrivateKey } from '..';
-
-// TODO: Rewrite decrypt() to allow additional cryptographic algorithms to be added easily then remove dependency on 'node-jose'.
-const jose = require('node-jose');
+import PrivateKey from '../security/PrivateKey';
 
 /**
  * Definition for a delegate that can encrypt data.
@@ -113,9 +110,9 @@ export default class JweToken extends JoseToken {
     //    BASE64URL(JWE Authentication Tag)
     const base64EncodedValues = this.content.split('.');
     // 2. Base64url decode the encoded header, encryption key, iv, ciphertext, and auth tag
-    const [headerString, encryptedKey, iv, _, authTag] =
+    const [headerString, encryptedKey, iv, ciphertextAsText, authTag] =
       base64EncodedValues.map((encodedValue) => { return Base64Url.decode(encodedValue); });
-    const ciphertext = Base64Url.toBase64(base64EncodedValues[3])
+    const ciphertext = Buffer.from(ciphertextAsText, 'utf8').toString('base64');
     // 3. let the JWE Header be a JSON object
     const headers = JSON.parse(headerString);
     // 4. only applies to JWE JSON Serializaiton

--- a/lib/security/JwsToken.ts
+++ b/lib/security/JwsToken.ts
@@ -3,9 +3,6 @@ import JoseToken from './JoseToken';
 import PublicKey from '../security/PublicKey';
 import { PrivateKey } from '..';
 
-// TODO: Rewrite sign() to allow additional cryptographic algorithms to be added easily then remove dependency on 'node-jose'.
-const jose = require('node-jose');
-
 /**
  * Definition for a delegate that can verfiy signed data.
  */
@@ -37,7 +34,7 @@ export default class JwsToken extends JoseToken {
     const signatureInput = `${encodedHeaders}.${encodedContent}`;
     const signature = await (this.cryptoFactory.getSigner(headers['alg'])).sign(signatureInput, jwk);
     // 6. Compute BASE64URL(JWS Signature)
-    const encodedSignature = Base64Url.encode(signature);
+    const encodedSignature = Base64Url.fromBase64(signature);
     // 7. Only applies to JWS JSON Serializaiton
     // 8. Create the desired output: BASE64URL(UTF8(JWS Header)) || . BASE64URL(JWS payload) || . || BASE64URL(JWS Signature)
     return `${signatureInput}.${encodedSignature}`;

--- a/lib/security/JwsToken.ts
+++ b/lib/security/JwsToken.ts
@@ -31,7 +31,7 @@ export default class JwsToken extends JoseToken {
     headers['alg'] = jwk.defaultSignAlgorithm;
     headers['kid'] = jwk.kid;
     // 4. Compute BASE64URL(UTF8(JWS Header))
-    const encodedHeaders = Base64Url.encode(JSON.stringify(headers))
+    const encodedHeaders = Base64Url.encode(JSON.stringify(headers));
     // 5. Compute the signature using data ASCII(BASE64URL(UTF8(JWS Header))) || . || . BASE64URL(JWS Payload)
     //    using the "alg" signature algorithm.
     const signatureInput = `${encodedHeaders}.${encodedContent}`;

--- a/lib/utilities/Base64Url.ts
+++ b/lib/utilities/Base64Url.ts
@@ -30,7 +30,7 @@ export default class Base64Url {
    * Converts a Base64URL string to a Base64 string.
    * TODO: Improve implementation perf.
    */
-  private static toBase64 (base64UrlString: string): string {
+  static toBase64 (base64UrlString: string): string {
     return (base64UrlString + '==='.slice((base64UrlString.length + 3) % 4))
       .replace(/-/g, '+')
       .replace(/_/g, '/');
@@ -40,7 +40,7 @@ export default class Base64Url {
    * Converts a Base64 string to a Base64URL string.
    * TODO: Improve implementation perf.
    */
-  private static fromBase64 (base64String: string): string {
+  static fromBase64 (base64String: string): string {
     return base64String
       .replace(/\+/g, '-')
       .replace(/\//g, '_')

--- a/tests/Authentication.spec.ts
+++ b/tests/Authentication.spec.ts
@@ -165,12 +165,9 @@ describe('Authentication', () => {
       };
       const jws = new JwsToken(payload, registry);
 
-      const unknownKeyHeader = {
-        alg: 'RS256',
-        kid: 'did:example:123456789abcdefghi#unknown-key'
-      };
+      const unknownPublicKey = await PrivateKeyRsa.generatePrivateKey(`${exampleDID}#unknown-key`);
 
-      const data = await jws.sign(examplekey, unknownKeyHeader);
+      const data = await jws.sign(unknownPublicKey);
 
       const jwe = new JweToken(data, registry);
       const request = await jwe.encrypt(hubPublicKey);

--- a/tests/mocks/TestCryptoProvider.ts
+++ b/tests/mocks/TestCryptoProvider.ts
@@ -39,7 +39,7 @@ export default class TestCryptoSuite implements CryptoSuite {
   private sign (id: number): ({}, {}) => Promise<string> {
     return (_, __) => {
       TestCryptoSuite.called[id] |= TestCryptoSuite.SIGN;
-      return Promise.reject(null);
+      return Promise.resolve('');
     };
   }
 

--- a/tests/mocks/TestPrivateKey.ts
+++ b/tests/mocks/TestPrivateKey.ts
@@ -1,0 +1,13 @@
+import { TestPublicKey } from './TestPublicKey';
+import PrivateKey from '../../lib/security/PrivateKey';
+
+/**
+ * A private key object used for testing
+ */
+export default class TestPrivateKey extends TestPublicKey implements PrivateKey {
+  defaultSignAlgorithm = 'test';
+
+  getPublicKey (): TestPublicKey {
+    return this;
+  }
+}

--- a/tests/mocks/TestPublicKey.ts
+++ b/tests/mocks/TestPublicKey.ts
@@ -6,7 +6,7 @@ import PublicKey from '../../lib/security/PublicKey';
 export class TestPublicKey extends PublicKey {
   /** Its unique identifier */
   uid: number;
-  static readonly defaultEncryptionAlgorithm = 'test';
+  defaultEncryptionAlgorithm = 'test';
 
   constructor (kid?: string) {
     super();

--- a/tests/security/JweToken.spec.ts
+++ b/tests/security/JweToken.spec.ts
@@ -158,6 +158,23 @@ describe('JweToken', () => {
       jwe = new JweToken(message, registry);
       await expectToThrow(jwe, 'decrypt decrypted data with mis-matched headers', 'authenticat'); // e or ion
     });
+
+    it('should require the key ids to match', async () => {
+      const newMessage = usingheaders({
+        kty: 'test',
+        kid: privateKey.kid + '1',
+        enc: 'A128GCM',
+        alg: 'test'
+      });
+      const jwe = new JweToken(newMessage, registry);
+      await expectToThrow(jwe, 'decrypt succeeded when the private key does not match the headers key');
+    });
+
+    it('should decrypt encrypted JWEs', async () => {
+      const jwe = new JweToken(encryptedMessage, registry);
+      const payload = await jwe.decrypt(privateKey);
+      expect(payload).toEqual(plaintext);
+    });
   });
 
 });

--- a/tests/security/JweToken.spec.ts
+++ b/tests/security/JweToken.spec.ts
@@ -1,6 +1,8 @@
 import TestCryptoAlgorithms from '../mocks/TestCryptoProvider';
-import { PublicKey, JweToken } from '../../lib';
+import { PublicKey, JweToken, PrivateKey } from '../../lib';
 import CryptoRegistry from '../../lib/CryptoFactory';
+import TestPrivateKey from '../mocks/TestPrivateKey';
+import Base64Url from '../../lib/utilities/Base64Url';
 
 describe('JweToken', () => {
 
@@ -57,7 +59,105 @@ describe('JweToken', () => {
       const resultheaders = JSON.parse(headersString);
       expect(resultheaders['test']).toEqual(magicvalue);
     });
+  });
 
+  describe('decrypt', () => {
+    const crypto = new TestCryptoAlgorithms();
+    let registry = new CryptoRegistry([crypto]);
+    let privateKey: PrivateKey;
+    let plaintext: string;
+    let encryptedMessage: string;
+
+    beforeEach(async () => {
+      privateKey = new TestPrivateKey();
+      const pub = privateKey.getPublicKey();
+      plaintext = Math.round(Math.random() * Number.MAX_SAFE_INTEGER).toString(16);
+      const jwe = new JweToken(plaintext, registry);
+      encryptedMessage = (await jwe.encrypt(pub)).toString();
+    });
+
+    function usingheaders (headers: any): string {
+      const base64urlheaders = Base64Url.encode(JSON.stringify(headers));
+      const messageParts = encryptedMessage.split('.');
+      return `${base64urlheaders}.${messageParts[1]}.${messageParts[2]}.${messageParts[3]}.${messageParts[4]}`;
+    }
+
+    async function expectToThrow (jwe: JweToken, message: string, match?: string): Promise<void> {
+      try {
+        await jwe.decrypt(privateKey);
+        fail(message);
+      } catch (err) {
+        expect(err).toBeDefined();
+        if (match) {
+          expect(err.message.toLowerCase()).toContain(match.toLowerCase());
+        }
+      }
+    }
+
+    it('should fail for an unsupported encryption algorithm', async () => {
+      const newMessage = usingheaders({
+        kty: 'test',
+        kid: privateKey.kid,
+        alg: 'unknown',
+        enc: 'A128GCM'
+      });
+      const jwe = new JweToken(newMessage, registry);
+      await expectToThrow(jwe, 'decrypt suceeded with unknown encryption algorithm used');
+    });
+
+    it('should call the crypto Algorithms\'s encrypt', async () => {
+      const jwe = new JweToken(encryptedMessage.toString(), registry);
+      crypto.reset();
+      await jwe.decrypt(privateKey);
+      expect(crypto.wasDecryptCalled()).toBeTruthy();
+    });
+
+    it('should require headers', async () => {
+      const newMessage = usingheaders({
+        kty: 'test',
+        kid: privateKey.kid,
+        enc: 'A128GCM'
+      });
+      const jwe = new JweToken(newMessage, registry);
+      await expectToThrow(jwe, 'decrypt succeeded when a necessary header was omitted');
+    });
+
+    it('should check "crit" per RFC 7516 5.2.5 and RFC 7515 4.1.11', async () => {
+      let message = usingheaders({
+        kty: 'test',
+        kid: privateKey.kid,
+        enc: 'A128GCM',
+        alg: 'test',
+        test: 'A "required" field',
+        crit: [
+          'test'
+        ]
+      });
+      let jwe = new JweToken(message, registry);
+      await expectToThrow(jwe, 'decrypt succeeded when a "crit" header was included with unknown extensions', 'support');
+
+      message = usingheaders({
+        kty: 'test',
+        kid: privateKey.kid,
+        enc: 'A128GCM',
+        alg: 'test',
+        test: 'A "required" field',
+        crit: 1
+      });
+      jwe = new JweToken(message, registry);
+      await expectToThrow(jwe, 'decrypt succeeded when a "crit" header was malformed', 'malformed');
+
+      message = usingheaders({
+        kty: 'test',
+        kid: privateKey.kid,
+        enc: 'A128GCM',
+        alg: 'test',
+        test: 'A "required" field',
+        crit: []
+      });
+      jwe = new JweToken(message, registry);
+      await expectToThrow(jwe, 'decrypt decrypted data with mis-matched headers', 'authenticat'); // e or ion
+    });
   });
 
 });

--- a/tests/security/JwsToken.spec.ts
+++ b/tests/security/JwsToken.spec.ts
@@ -3,6 +3,7 @@ import TestCryptoAlgorithms from '../mocks/TestCryptoProvider';
 import Base64Url from '../../lib/utilities/Base64Url';
 import { TestPublicKey } from '../mocks/TestPublicKey';
 import CryptoRegistry from '../../lib/CryptoFactory';
+import TestPrivateKey from '../mocks/TestPrivateKey';
 
 describe('JwsToken', () => {
 
@@ -54,6 +55,35 @@ describe('JwsToken', () => {
       } catch (err) {
         // This signature will fail.
       }
+      expect(crypto.wasVerifyCalled()).toBeTruthy();
+    });
+  });
+
+  describe('sign', () => {
+    const crypto = new TestCryptoAlgorithms();
+    let registry = new CryptoRegistry([crypto]);
+
+    const data = {
+      description: 'JWSToken test'
+    };
+
+    it('should throw an error because algorithm unsupported', async () => {
+      const privateKey = new TestPrivateKey();
+      privateKey.defaultSignAlgorithm = 'unsupported';
+      const jwsToken = new JwsToken(data, registry);
+      try {
+        await jwsToken.sign(privateKey);
+      } catch (err) {
+        expect(err).toBeDefined();
+        return;
+      }
+      fail('Sign did not throw');
+    });
+
+    it('should call the crypto Algorithms\'s sign', async () => {
+      const jwsToken = new JwsToken(data, registry);
+      crypto.reset();
+      await jwsToken.sign(new TestPrivateKey());
       expect(crypto.wasVerifyCalled()).toBeTruthy();
     });
   });

--- a/tests/security/JwsToken.spec.ts
+++ b/tests/security/JwsToken.spec.ts
@@ -67,7 +67,7 @@ describe('JwsToken', () => {
       description: 'JWSToken test'
     };
 
-    it('should throw an error because algorithm unsupported', async () => {
+    it('should throw an error because the algorithm is not supported', async () => {
       const privateKey = new TestPrivateKey();
       privateKey.defaultSignAlgorithm = 'unsupported';
       const jwsToken = new JwsToken(data, registry);
@@ -84,7 +84,7 @@ describe('JwsToken', () => {
       const jwsToken = new JwsToken(data, registry);
       crypto.reset();
       await jwsToken.sign(new TestPrivateKey());
-      expect(crypto.wasVerifyCalled()).toBeTruthy();
+      expect(crypto.wasSignCalled()).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
Rewrites JWS `sign` and JWE `decrypt` to use CryptoSuite's `sign` and `decrypt` functionalities. 
Node-Jose is still in the package.json for RSA PrivateKeys ability to generate private keys.