### PR TITLE
Changes casing of keyOps so that jwk compliant

### DIFF
--- a/lib/Authentication.ts
+++ b/lib/Authentication.ts
@@ -5,6 +5,7 @@ import Constants from './Constants';
 import PublicKey from './security/PublicKey';
 import CryptoFactory from './CryptoFactory';
 import { RsaCryptoSuite } from './crypto/rsa/RsaCryptoSuite';
+import { Secp256k1CryptoSuite } from './crypto/ec/Secp256k1CryptoSuite';
 import JweToken from './security/JweToken';
 import JwsToken from './security/JwsToken';
 import uuid from 'uuid/v4';
@@ -46,7 +47,7 @@ export default class Authentication {
     this.resolver = options.resolver;
     this.tokenValidDurationInMinutes = options.tokenValidDurationInMinutes || Constants.defaultTokenDurationInMinutes;
     this.keys = options.keys;
-    this.factory = new CryptoFactory(options.cryptoSuites || [new RsaCryptoSuite()]);
+    this.factory = new CryptoFactory(options.cryptoSuites || [new RsaCryptoSuite(), new Secp256k1CryptoSuite()]);
   }
 
   /**

--- a/lib/crypto/ec/EcPrivateKey.ts
+++ b/lib/crypto/ec/EcPrivateKey.ts
@@ -1,6 +1,6 @@
 import EcPublicKey from './EcPublicKey';
 import PrivateKey from '../../security/PrivateKey';
-import PublicKey from '../../security/PublicKey';
+import PublicKey, { KeyOperation } from '../../security/PublicKey';
 import { DidPublicKey } from '@decentralized-identity/did-common-typescript';
 
 const ecKey = require('ec-key');
@@ -54,7 +54,8 @@ export default class EcPrivateKey extends EcPublicKey implements PrivateKey {
     // Add the additional JWK parameters
     const jwk = Object.assign(key.toJSON(), {
       kid: kid,
-      alg: 'ES256K'
+      alg: 'ES256K',
+      key_ops: [KeyOperation.Sign, KeyOperation.Verify]
     });
 
     return EcPrivateKey.wrapJwk(kid, jwk);
@@ -67,6 +68,7 @@ export default class EcPrivateKey extends EcPublicKey implements PrivateKey {
       crv: this.crv,
       x: this.x,
       y: this.y,
+      use: 'verify',
       defaultEncryptionAlgorithm: 'none'
     } as EcPublicKey;
   }

--- a/lib/crypto/ec/EcPublicKey.ts
+++ b/lib/crypto/ec/EcPublicKey.ts
@@ -37,6 +37,8 @@ export default class EcPublicKey extends PublicKey {
       this.crv = jwk.crv;
       this.x = jwk.x;
       this.y = jwk.y;
+      this.key_ops = jwk.key_ops;
+      this.use = this.use;
     } else {
       throw new Error('Cannot parse Elliptic Curve key.');
     }

--- a/lib/security/PublicKey.ts
+++ b/lib/security/PublicKey.ts
@@ -38,7 +38,7 @@ export default abstract class PublicKey {
   /** Intended use */
   use?: string; // "sig" "enc"
   /** Valid key operations (key_ops) */
-  keyOps?: KeyOperation[];
+  key_ops?: KeyOperation[];
   /** Algorithm intended for use with this key */
   alg?: string;
   /** A resource for a X.509 public key certificate */

--- a/tests/crypto/ec/EcPrivateKey.spec.ts
+++ b/tests/crypto/ec/EcPrivateKey.spec.ts
@@ -1,4 +1,5 @@
 import EcPrivateKey from '../../../lib/crypto/ec/EcPrivateKey';
+import { KeyOperation } from '../../../lib/security/PublicKey';
 
 describe('EcPrivateKey', async () => {
   it('constructor should throw when no jwk.d', async () => {
@@ -24,6 +25,7 @@ describe('EcPrivateKey', async () => {
     expect(ecKey).toBeDefined();
     expect(ecKey.kty).toEqual('EC');
     expect(ecKey.kid).toEqual('key-1');
+    expect(ecKey.key_ops).toEqual([KeyOperation.Sign, KeyOperation.Verify]);
     expect(ecKey.defaultEncryptionAlgorithm).toEqual('none');
     expect(ecKey.crv).toEqual('P-256K');
     expect(ecKey.defaultSignAlgorithm).toEqual('ES256K');

--- a/tslint.json
+++ b/tslint.json
@@ -58,7 +58,8 @@
     "variable-name": [
       true, 
       "allow-leading-underscore",
-      "check-format"
+      "check-format",
+      "allow-snake-case"
     ]
   }
 }


### PR DESCRIPTION
Adds tslint variable rule allowing snake casing to make PublicKey JSON JWK representation compliant.
