### PR TITLE
Always return aad in encrypted payload

### DIFF
--- a/lib/crypto/rsa/RsaCryptoSuite.ts
+++ b/lib/crypto/rsa/RsaCryptoSuite.ts
@@ -13,6 +13,7 @@ import PublicKey from '../../security/PublicKey';
  */
 export class RsaCryptoSuite implements CryptoSuite {
 
+  /** Get symmetric key encryptors */
   getSymmetricEncrypters (): { [algorithm: string]: SymmetricEncrypter } {
     return {};
   }

--- a/lib/crypto/rsa/RsaPrivateKey.ts
+++ b/lib/crypto/rsa/RsaPrivateKey.ts
@@ -7,6 +7,7 @@ const jose = require('node-jose');
 const keystore = jose.JWK.createKeyStore();
 
 /**
+ * TODO - evaluate if we need to support other.
  * Represents Other primes info (RFC7518 6.3.2.7)
  */
 type OtherPrime = {
@@ -22,6 +23,8 @@ type OtherPrime = {
  */
 export default class RsaPrivateKey extends RsaPublicKey implements PrivateKey {
 
+  // TODO change to alg and the value is depending on the used sha algorithm
+  /** default algorithm */
   readonly defaultSignAlgorithm: string = 'RS256';
 
   /** Private exponent as specified by RFC7518 6.3.2.1 */
@@ -95,6 +98,7 @@ export default class RsaPrivateKey extends RsaPublicKey implements PrivateKey {
     return RsaPrivateKey.wrapJwk(kid, keygen.toJSON(true));
   }
 
+  /** Get the public key */
   getPublicKey (): PublicKey {
     return {
       kty: this.kty,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1292,7 +1292,7 @@
     },
     "ec-key": {
       "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/ec-key/-/ec-key-0.0.2.tgz",
+      "resolved": "https://msazure.pkgs.visualstudio.com/_packaging/AD-DID-Packages/npm/registry/ec-key/-/ec-key-0.0.2.tgz",
       "integrity": "sha1-UAUq6WGr1vGHEMI1qH80mnJGgYk=",
       "requires": {
         "asn1.js": "^1.0.4"
@@ -1434,7 +1434,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
@@ -1883,7 +1883,7 @@
     },
     "load-json-file": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
@@ -2003,7 +2003,7 @@
     },
     "marked": {
       "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+      "resolved": "http://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
       "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
       "dev": true
     },
@@ -2049,7 +2049,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -3712,7 +3712,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -4057,7 +4057,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {

--- a/tests/security/JweToken.spec.ts
+++ b/tests/security/JweToken.spec.ts
@@ -235,7 +235,7 @@ describe('JweToken', () => {
       } as PublicKey;
       const protectedValue = Math.round(Math.random()).toString(16);
       const unprotectedValue = Math.round(Math.random()).toString(16);
-      const aad = Math.round(Math.random()).toString(16);
+      const aad = Math.round(Math.random() * Number.MAX_SAFE_INTEGER).toString(16);
       const plaintext = Math.round(Math.random()).toString(16);
       const jwe = new JweToken(plaintext, registry);
       crypto.reset();
@@ -250,10 +250,10 @@ describe('JweToken', () => {
       });
       expect(crypto.wasEncryptCalled()).toBeTruthy();
       expect(encrypted).toBeDefined();
-      expect(encrypted.aad).toEqual(Base64Url.encode(aad));
       expect(encrypted.unprotected!['test']).toEqual(unprotectedValue);
       expect(JSON.parse(Base64Url.decode(encrypted.protected!))['test']).toEqual(protectedValue);
       expect(encrypted.ciphertext).not.toEqual(plaintext);
+      expect(encrypted.aad).toEqual([encrypted.protected, Base64Url.encode(aad)].join('.'));
     });
   });
 
@@ -379,7 +379,7 @@ describe('JweToken', () => {
       const encrypted = await jweToEncrypt.encryptAsFlattenedJson(pub, {
         aad
       });
-      expect(encrypted.aad).toEqual(Base64Url.encode(aad));
+      expect(encrypted.aad).toEqual([encrypted.protected, Base64Url.encode(aad)].join('.'));
       const jwe = new JweToken(encrypted, registry);
       const payload = await jwe.decrypt(privateKey);
       expect(payload).toEqual(plaintext);


### PR DESCRIPTION
Add the aad value to the flat JWE format.
This value must correspond to the actual integrity protected value.