### PR TITLE
revise sign algorithm for Secp256k1CryptoSuite

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
   "license": "ISC",
   "dependencies": {
     "@decentralized-identity/did-common-typescript": "0.1.19",
+    "@trust/keyto": "^0.3.7",
     "ec-key": "0.0.2",
     "jwk-to-pem": "2.0.0",
     "node-jose": "1.0.0",
+    "secp256k1": "^3.7.1",
     "uuid": "3.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
As mentioned in https://github.com/decentralized-identity/did-auth-jose/issues/32, change sign module `ec-key` for spec256k1